### PR TITLE
adding step order and logic to avoid failures if initial test fails

### DIFF
--- a/python-createTC/createTCAndUploadResults.py
+++ b/python-createTC/createTCAndUploadResults.py
@@ -250,9 +250,10 @@ def GetRuns(suiteId):
                             m = re.search('test-cases/(\d+)\?versionId', link['href'])
                             tcIds.append(m.group(1))
                             run['tcid'] = m.group(1)
-
-                            tcMatch = testcases[run['tcid']]
-                            existingRuns[tcMatch['automationcontent']] = run
+                            #Avoid failures when initial test run fails
+                            if run['tcid'] in testcases:
+                                tcMatch = testcases[run['tcid']]
+                                existingRuns[tcMatch['automationcontent']] = run
 
         return existingRuns
 
@@ -303,6 +304,9 @@ def CreateLog(testResult, testRunId):
     note = ""
 
     stepLogObj = []
+    
+    #Add a step count to avoid failures with test step and test status 
+    step_count = 0;
     for step in testResult['steps']:
         
         if('status' in step):
@@ -314,9 +318,11 @@ def CreateLog(testResult, testRunId):
                 "description": step['description'],
                 "expected_result": step['expected'],
                 "status": step['status']
+                "order": step_count
             }
 
         stepLogObj.append(stepLog)
+        step_
 
     body = {
         "status" : parentStatus,


### PR DESCRIPTION
1) Add step order to avoid mismatch in test step status

2) Avoid failures when updating test runs under a test suite. This usually happens when we try to update test cases that are not present in the test suite but get pulled in to Test Runs. 
